### PR TITLE
Fix for missing double quote in employees.json example

### DIFF
--- a/locales/en/read_data.md
+++ b/locales/en/read_data.md
@@ -112,10 +112,10 @@ JSON has become the language of the internet for good reason. Its easy to unders
 employees.json:
 
 [
- {"name":"Andy Hunt,
- "title":"Big Boss",
-   "age": 68,
-   "bonus": true
+ {"name":"Andy Hunt",
+  "title":"Big Boss",
+  "age": 68,
+  "bonus": true
  },
  {"name":"Charles Mack",
   "title":"Jr Dev",


### PR DESCRIPTION
![screen shot 2015-03-26 at 8 36 02 pm](https://cloud.githubusercontent.com/assets/201320/6860012/d0835ed2-d3f7-11e4-9820-c76d73b340b8.png)
